### PR TITLE
Fix handling of unexpected Unicode input in matching logic

### DIFF
--- a/src/bunnyDenial.ts
+++ b/src/bunnyDenial.ts
@@ -6,6 +6,7 @@ export function matchPattern(content: string): boolean {
     .normalize("NFKD")
     .replace(/([0-9])\u{FE0F}\u{20E3}/gu, "$1") // Normalize Keycap Digits
     .replace(/(?:[\s()]|<.*>)/g, "") // Remove spaces, mentions and emojis
+    .replace(/\p{Mn}/gu, "") // Remove Unicode combining marks properly
     .match(
       /(?:[⛔🚫❌🙅]+|[不八捌8⓼➑][是四肆4⓸➍]|not)(?:一隻|a)?(?:[兔ㄊ二貳2⓶➋🐰🐇]+|two|bunny|rabbit)/iu,
     );

--- a/tests/bunnyDenial.test.ts
+++ b/tests/bunnyDenial.test.ts
@@ -12,6 +12,7 @@ test("matchPattern should correctly identify bunny denial messages", async (t) =
     "我 不是 ²²",
     "我 8 ⁴ 22！！！！",
     "8️⃣4️⃣2️⃣2️⃣",
+    "Nöt 22",
   ];
 
   await t.test("should return true for valid bunny patterns", () => {


### PR DESCRIPTION
### Why

Some Unicode inputs (accented characters) were not correctly matched, causing bugs in input validation.


### How

- Remove combining marks with Unicode property regex


### Impact

This improves matching accuracy and prevents false negatives in input handling.